### PR TITLE
[2] Bumped co-log-core dependency to >= 0.3

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,9 @@
 # Revision history for co-log-concurent
 
+## 0.5.0.1 -- 2022-08-03
+  - Bumped co-log-core version to ^>= 0.3.
+  - Bumped stack resolver to lts-18.19 (GHC 8.10.7)
+
 ## 0.5.0.0 --
 
 * API changes:

--- a/co-log-concurrent.cabal
+++ b/co-log-concurrent.cabal
@@ -55,7 +55,7 @@ library
   exposed-modules:     Colog.Concurrent
                        Colog.Concurrent.Internal
 
-  build-depends:       co-log-core ^>= 0.2.1.0
+  build-depends:       co-log-core ^>= 0.3
                      , stm >= 2.4 && < 2.6
   default-language:    Haskell2010
   default-extensions:  ConstraintKinds

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,7 @@
-resolver: lts-15.8
+resolver: lts-18.19
 
 packages:
   - ./
+
+extra-deps:
+  - co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816


### PR DESCRIPTION
This is the pull request to issue https://github.com/qnikst/co-log-concurrent/issues/2